### PR TITLE
accept header (json) required as of 5.5 #115

### DIFF
--- a/customization/harvard-dataverse-homepage.html
+++ b/customization/harvard-dataverse-homepage.html
@@ -354,13 +354,13 @@
     function querySubjectDataverseDataset(elm) {
         var dvArray = [];
         var fullArray = [];
-        $.get(metricBaseUrl + "dataverses/bySubject", function(jData) {
+        $.ajax({url: metricBaseUrl + "dataverses/bySubject", headers: { "Accept": "application/json" }, success: function(jData) {
             jData.data.forEach(function(item) {
                 if(item.subject !== "N/A" && item.subject !== "Other") {
                     dvArray.push([item.subject, item.count]);
                 }
             });
-            $.get(metricBaseUrl + "datasets/bySubject?dataLocation=all", function(jData) {
+            $.ajax({url: metricBaseUrl + "datasets/bySubject?dataLocation=all", headers: { "Accept": "application/json" }, success: function(jData) {
                 var resultHtml = "";
                 jData.data.forEach(function(item) {
                     if(item.subject !== "N/A" && item.subject !== "Other") {
@@ -380,8 +380,8 @@
                     resultHtml += "<p class=\"browse-subjects\"><a href=\"/dataverse/harvard?q=&fq0=subject_ss%3A%22" + subject[0] + "%22&types=dataverses%3Adatasets&sort=dateSort&order=desc\">" + subject[0] + "</a> <span class=\"text-muted\">" + subject[1] + "</span></p>";
                 });
                 document.getElementById(elm).innerHTML = resultHtml;
-            });
-        });
+            }});
+        }});
     }
 
     // queryMetricSimple("datasets", "?dataLocation=all", ["headAllTimeAllDatasetsValue", "activityAllTimeAllDatasetsValue"]);


### PR DESCRIPTION
Closes #115

As of Dataverse 5.5, specifically
https://github.com/IQSS/dataverse/pull/7178 , an "Accept" header is
required to download metrics in JSON format (the default is CSV).

This was affecting the retrieval of subjects. Here's how it looks for me with the fix (with minimal data on my laptop):

<img width="968" alt="Screen Shot 2021-06-24 at 4 14 22 PM" src="https://user-images.githubusercontent.com/21006/123326500-50ae0000-d507-11eb-825e-b906244d477a.png">

The issue also mentioned uncommenting some metrics but this change (the commenting) was never checked into the repo so there's nothing to change in this pull request. When uncommenting, the expected content should look something like this:

<img width="1213" alt="Screen Shot 2021-06-24 at 4 07 21 PM" src="https://user-images.githubusercontent.com/21006/123326681-87841600-d507-11eb-8eda-f030088dc3db.png">
