### PR TITLE
Allow Multiple Data Sources in CAFE Metadata Block

### DIFF
--- a/metadatablocks/customCAFEDataSources.tsv
+++ b/metadatablocks/customCAFEDataSources.tsv
@@ -2,23 +2,23 @@
 	customCAFEDataSources	CAFE	Metadata About Data Sources													
 #datasetField	name	title	description	watermark	fieldType	displayOrder	displayFormat	advancedSearchField	allowControlledVocabulary	allowmultiples	facetable	displayoncreate	required	parent	metadatablock_id	termURI
 	cafeDerivedFromExistingDataset	Derived from Another Dataset	Indicates if this Dataset is derived from another dataset, such as a climate model		text	0		FALSE	TRUE	FALSE	TRUE	TRUE	TRUE		customCAFEDataSources	
-	cafeSourceDataTitle	Source Dataset Title	The name or title of the dataset from which this Dataset is derived		text	1		TRUE	FALSE	FALSE	TRUE	TRUE	FALSE		customCAFEDataSources	
-	cafeSourceDataAuthor	Source Dataset Author	The author of the source dataset		text	2		TRUE	FALSE	TRUE	TRUE	TRUE	FALSE		customCAFEDataSources	
-	cafeSourceDataInstitution	Source Dataset Institution	The institution or organization at which the source dataset was created, e.g. NASA		text	3		TRUE	FALSE	FALSE	TRUE	TRUE	FALSE		customCAFEDataSources	
-	cafeSourceDataVersionNumber	Source Dataset Version Number	The version number of the source data		text	4		FALSE	FALSE	FALSE	FALSE	TRUE	FALSE		customCAFEDataSources	
-	cafeSourceDataDOIOrURL	Source Dataset DOI or URL	The unique identifier or web URL to the source dataset	https://	url	5	<a href="#VALUE" target="_blank">#VALUE</a>	TRUE	FALSE	FALSE	TRUE	TRUE	FALSE		customCAFEDataSources	
-	cafeSourceDataLastModifiedDate	Source Dataset Last Modified Date	The date on which the source dataset was last modified, as used in the derivation of this Dataset	YYYY-MM-DD	date	6		FALSE	FALSE	FALSE	FALSE	TRUE	FALSE		customCAFEDataSources	
-	cafeSourceDataDateObtained	Source Dataset Date Obtained	The date when this Dataset's depositor obtained the source dataset	YYYY-MM-DD	date	7		FALSE	FALSE	FALSE	FALSE	TRUE	FALSE		customCAFEDataSources	
-	cafeSourceDataType	Source Dataset Type	A broad categorization of the source data by method of data creation		text	8		TRUE	TRUE	FALSE	TRUE	TRUE	FALSE		customCAFEDataSources	
-	cafeSourceDataTypeOther	Source Dataset Other Type	A broad categorization of the source data by method of data creation		text	9		FALSE	FALSE	FALSE	FALSE	TRUE	FALSE		customCAFEDataSources	
-	cafeSourceDataSpatialResolution	Source Dataset Spatial Resolution	The spatial resolution of the raster data		none	10	;	FALSE	FALSE	FALSE	FALSE	TRUE	FALSE		customCAFEDataSources	
-	cafeSourceDataSpatialValue	Value	The horizontal grid spacing of the source data as a number with no unit		float	11	#NAME: #VALUE	TRUE	FALSE	FALSE	TRUE	TRUE	FALSE	cafeSourceDataSpatialResolution	customCAFEDataSources	
-	cafeSourceDataSpatialResolutionUnit	Unit	The unit of the Spatial Resolution		text	12	#NAME: #VALUE	TRUE	TRUE	FALSE	TRUE	TRUE	FALSE	cafeSourceDataSpatialResolution	customCAFEDataSources	
-	cafeSourceDataSpatialResolutionUnitOther	Other Unit	The unit of the Spatial Resolution		text	13	#NAME: #VALUE	FALSE	FALSE	FALSE	FALSE	TRUE	FALSE	cafeSourceDataSpatialResolution	customCAFEDataSources	
-	cafeSourceDataTimestep	Source Dataset Timestep	The temporal frequency of data in the source dataset		text	14		TRUE	TRUE	FALSE	TRUE	TRUE	FALSE		customCAFEDataSources	
-	cafeSourceDataTimestepOther	Other Source Dataset Timestep	The temporal frequency of data in the source dataset		text	15		FALSE	FALSE	FALSE	FALSE	TRUE	FALSE		customCAFEDataSources	
-	cafeSourceDataAttribution	Source Dataset Attribution	Bibliographic references to the source data, which are typically included in the terms of use		textbox	16		FALSE	FALSE	FALSE	FALSE	TRUE	FALSE		customCAFEDataSources	
-	cafeSourceDataDisclaimer	Source Dataset Disclaimer	Disclaimer text provided by the source dataset creators		textbox	17		FALSE	FALSE	FALSE	FALSE	TRUE	FALSE		customCAFEDataSources	
+	cafeSourceData	Source Dataset	Information about the source dataset		none	1	;	TRUE	FALSE	TRUE	TRUE	TRUE	FALSE		customCAFEDataSources	
+	cafeSourceDataTitle	Source Dataset Title	The name or title of the dataset from which this Dataset is derived		text	2	#NAME: #VALUE	TRUE	FALSE	FALSE	TRUE	TRUE	FALSE	cafeSourceData	customCAFEDataSources	
+	cafeSourceDataAuthor	Source Dataset Author	The author of the source dataset		text	3	#NAME: #VALUE	TRUE	FALSE	TRUE	TRUE	TRUE	FALSE	cafeSourceData	customCAFEDataSources	
+	cafeSourceDataInstitution	Source Dataset Institution	The institution or organization at which the source dataset was created		text	4	#NAME: #VALUE	TRUE	FALSE	FALSE	TRUE	TRUE	FALSE	cafeSourceData	customCAFEDataSources	
+	cafeSourceDataVersionNumber	Source Dataset Version Number	The version number of the source data		text	5	#NAME: #VALUE	FALSE	FALSE	FALSE	FALSE	TRUE	FALSE	cafeSourceData	customCAFEDataSources	
+	cafeSourceDataDOIOrURL	Source Dataset DOI or URL	The unique identifier or web URL to the source dataset	https://	url	6	<a href="#VALUE" target="_blank">#VALUE</a>	TRUE	FALSE	FALSE	TRUE	TRUE	FALSE	cafeSourceData	customCAFEDataSources	
+	cafeSourceDataLastModifiedDate	Source Dataset Last Modified Date	The date on which the source dataset was last modified	YYYY-MM-DD	date	7	#NAME: #VALUE	FALSE	FALSE	FALSE	FALSE	TRUE	FALSE	cafeSourceData	customCAFEDataSources	
+	cafeSourceDataDateObtained	Source Dataset Date Obtained	The date when this Dataset's depositor obtained the source dataset	YYYY-MM-DD	date	8	#NAME: #VALUE	FALSE	FALSE	FALSE	FALSE	TRUE	FALSE	cafeSourceData	customCAFEDataSources	
+	cafeSourceDataType	Source Dataset Type	A broad categorization of the source data by method of data creation		text	9	#NAME: #VALUE	TRUE	TRUE	FALSE	TRUE	TRUE	FALSE	cafeSourceData	customCAFEDataSources	
+	cafeSourceDataTypeOther	Source Dataset Other Type	A broad categorization of the source data by method of data creation		text	10	#NAME: #VALUE	FALSE	FALSE	FALSE	FALSE	TRUE	FALSE	cafeSourceData	customCAFEDataSources	
+	cafeSourceDataSpatialResolution	Source Dataset Spatial Resolution	The horizontal grid spacing of the source data as a number with no unit		float	11	#NAME: #VALUE	TRUE	FALSE	FALSE	TRUE	TRUE	FALSE	cafeSourceData	customCAFEDataSources	
+	cafeSourceDataSpatialResolutionUnit	Source Dataset Spatial Resolution Unit	The unit of the Spatial Resolution		text	12	#NAME: #VALUE	TRUE	TRUE	FALSE	TRUE	TRUE	FALSE	cafeSourceData	customCAFEDataSources	
+	cafeSourceDataSpatialResolutionUnitOther	Source Dataset Spatial Resolution Other Unit	The unit of the Spatial Resolution		text	13	#NAME: #VALUE	FALSE	FALSE	FALSE	FALSE	TRUE	FALSE	cafeSourceData	customCAFEDataSources	
+	cafeSourceDataTimestep	Source Dataset Timestep	The temporal frequency of data in the source dataset		text	14	#NAME: #VALUE	TRUE	TRUE	FALSE	TRUE	TRUE	FALSE	cafeSourceData	customCAFEDataSources	
+	cafeSourceDataTimestepOther	Other Source Dataset Timestep	The temporal frequency of data in the source dataset		text	15	#NAME: #VALUE	FALSE	FALSE	FALSE	FALSE	TRUE	FALSE	cafeSourceData	customCAFEDataSources	
+	cafeSourceDataAttribution	Source Dataset Attribution	Bibliographic references to the source data, which are typically included in the terms of use		textbox	16	#NAME: #VALUE	FALSE	FALSE	FALSE	FALSE	TRUE	FALSE	cafeSourceData	customCAFEDataSources	
+	cafeSourceDataDisclaimer	Source Dataset Disclaimer	Disclaimer text provided by the source dataset creators		textbox	17	#NAME: #VALUE	FALSE	FALSE	FALSE	FALSE	TRUE	FALSE	cafeSourceData	customCAFEDataSources	
 #controlledVocabulary	DatasetField	Value	identifier	displayOrder												
 	cafeDerivedFromExistingDataset	Yes		0												
 	cafeDerivedFromExistingDataset	No		1												

--- a/src/main/resources/db/migration/V6.6.0.1__cafe-metadata-restructure.sql
+++ b/src/main/resources/db/migration/V6.6.0.1__cafe-metadata-restructure.sql
@@ -1,0 +1,672 @@
+-- Crear campo compuesto 'cafeSourceData' si no existe para cada dataset con datos
+INSERT INTO datasetfield (datasetversion_id, datasetfieldtype_id)
+SELECT DISTINCT df.datasetversion_id,
+       dft_comp.id
+FROM datasetfield df
+JOIN datasetfieldtype dft ON df.datasetfieldtype_id = dft.id
+JOIN datasetfieldtype dft_comp ON dft_comp.name = 'cafeSourceData'
+WHERE dft.name IN (
+    'cafeSourceDataTitle',
+    'cafeSourceDataAuthor',
+    'cafeSourceDataInstitution',
+    'cafeSourceDataVersionNumber',
+    'cafeSourceDataDOIOrURL',
+    'cafeSourceDataLastModifiedDate',
+    'cafeSourceDataDateObtained',
+    'cafeSourceDataType',
+    'cafeSourceDataTypeOther',
+    'cafeSourceDataSpatialResolution',
+    'cafeSourceDataSpatialResolutionUnit',
+    'cafeSourceDataSpatialResolutionUnitOther',
+    'cafeSourceDataTimestep',
+    'cafeSourceDataTimestepOther',
+    'cafeSourceDataAttribution',
+    'cafeSourceDataDisclaimer'
+)
+  AND NOT EXISTS (
+    SELECT 1 FROM datasetfield df2 
+    WHERE df2.datasetversion_id = df.datasetversion_id 
+      AND df2.datasetfieldtype_id = dft_comp.id
+);
+
+-- Crear compoundvalue si no existe
+INSERT INTO datasetfieldcompoundvalue (parentdatasetfield_id, displayorder)
+SELECT df.id, 0
+FROM datasetfield df
+JOIN datasetfieldtype dft ON df.datasetfieldtype_id = dft.id
+WHERE dft.name = 'cafeSourceData'
+  AND NOT EXISTS (
+    SELECT 1 FROM datasetfieldcompoundvalue dfcv 
+    WHERE dfcv.parentdatasetfield_id = df.id
+);
+
+-- === cafeSourceDataTitle ===
+INSERT INTO datasetfield (datasetfieldtype_id, parentdatasetfieldcompoundvalue_id)
+SELECT dft_new.id, dfcv.id FROM datasetfield df_comp
+JOIN datasetfieldtype dft_comp ON df_comp.datasetfieldtype_id = dft_comp.id AND dft_comp.name = 'cafeSourceData'
+JOIN datasetfieldcompoundvalue dfcv ON dfcv.parentdatasetfield_id = df_comp.id
+JOIN datasetfield df_old ON df_old.datasetversion_id = df_comp.datasetversion_id
+JOIN datasetfieldtype dft_old ON df_old.datasetfieldtype_id = dft_old.id AND dft_old.name = 'cafeSourceDataTitle'
+JOIN datasetfieldtype dft_new ON dft_new.name = 'cafeSourceDataTitle'
+WHERE EXISTS (SELECT 1 FROM datasetfieldvalue dfv WHERE dfv.datasetfield_id = df_old.id)
+  AND NOT EXISTS (
+    SELECT 1 FROM datasetfield df_new2
+    JOIN datasetfieldtype dft_new2 ON df_new2.datasetfieldtype_id = dft_new2.id AND dft_new2.name = 'cafeSourceDataTitle'
+    WHERE df_new2.parentdatasetfieldcompoundvalue_id = dfcv.id
+  );
+
+INSERT INTO datasetfieldvalue (datasetfield_id, value)
+SELECT df_new.id, dfv.value FROM datasetfield df_new
+JOIN datasetfieldtype dft_new ON df_new.datasetfieldtype_id = dft_new.id AND dft_new.name = 'cafeSourceDataTitle'
+JOIN datasetfieldcompoundvalue dfcv ON df_new.parentdatasetfieldcompoundvalue_id = dfcv.id
+JOIN datasetfield df_comp ON dfcv.parentdatasetfield_id = df_comp.id
+JOIN datasetfieldtype dft_comp ON df_comp.datasetfieldtype_id = dft_comp.id AND dft_comp.name = 'cafeSourceData'
+JOIN datasetfield df_old ON df_old.datasetversion_id = df_comp.datasetversion_id
+JOIN datasetfieldtype dft_old ON df_old.datasetfieldtype_id = dft_old.id AND dft_old.name = 'cafeSourceDataTitle'
+JOIN datasetfieldvalue dfv ON dfv.datasetfield_id = df_old.id;
+
+DELETE FROM datasetfieldvalue WHERE datasetfield_id IN (
+    SELECT df.id FROM datasetfield df JOIN datasetfieldtype dft ON df.datasetfieldtype_id = dft.id
+    WHERE dft.name = 'cafeSourceDataTitle' AND df.parentdatasetfieldcompoundvalue_id IS NULL
+);
+
+DELETE FROM datasetfield WHERE datasetfieldtype_id = (
+    SELECT id FROM datasetfieldtype WHERE name = 'cafeSourceDataTitle'
+) AND parentdatasetfieldcompoundvalue_id IS NULL;
+
+-- === cafeSourceDataAuthor ===
+-- Primero, crear el campo compuesto para cada dataset que tenga valores de autor
+INSERT INTO datasetfield (datasetfieldtype_id, parentdatasetfieldcompoundvalue_id)
+SELECT dft_new.id, dfcv.id FROM datasetfield df_comp
+JOIN datasetfieldtype dft_comp ON df_comp.datasetfieldtype_id = dft_comp.id AND dft_comp.name = 'cafeSourceData'
+JOIN datasetfieldcompoundvalue dfcv ON dfcv.parentdatasetfield_id = df_comp.id
+JOIN datasetfield df_old ON df_old.datasetversion_id = df_comp.datasetversion_id
+JOIN datasetfieldtype dft_old ON df_old.datasetfieldtype_id = dft_old.id AND dft_old.name = 'cafeSourceDataAuthor'
+JOIN datasetfieldtype dft_new ON dft_new.name = 'cafeSourceDataAuthor'
+WHERE EXISTS (SELECT 1 FROM datasetfieldvalue dfv WHERE dfv.datasetfield_id = df_old.id)
+  AND NOT EXISTS (
+    SELECT 1 FROM datasetfield df_new2
+    JOIN datasetfieldtype dft_new2 ON df_new2.datasetfieldtype_id = dft_new2.id AND dft_new2.name = 'cafeSourceDataAuthor'
+    WHERE df_new2.parentdatasetfieldcompoundvalue_id = dfcv.id
+  );
+
+-- Luego, insertar los valores de autor
+-- Para cada dataset, crear un solo valor concatenado con todos los autores
+-- Usando array_agg con ORDER BY para mantener el orden original y punto y coma como separador
+INSERT INTO datasetfieldvalue (datasetfield_id, value)
+SELECT 
+    df_new.id, 
+    (
+        SELECT array_to_string(array_agg(dfv2.value ORDER BY dfv2.id), '; ')
+        FROM datasetfield df_old2
+        JOIN datasetfieldtype dft_old2 ON df_old2.datasetfieldtype_id = dft_old2.id AND dft_old2.name = 'cafeSourceDataAuthor'
+        JOIN datasetfieldvalue dfv2 ON dfv2.datasetfield_id = df_old2.id
+        WHERE df_old2.datasetversion_id = df_comp.datasetversion_id
+    ) AS concatenated_value
+FROM datasetfield df_new
+JOIN datasetfieldtype dft_new ON df_new.datasetfieldtype_id = dft_new.id AND dft_new.name = 'cafeSourceDataAuthor'
+JOIN datasetfieldcompoundvalue dfcv ON df_new.parentdatasetfieldcompoundvalue_id = dfcv.id
+JOIN datasetfield df_comp ON dfcv.parentdatasetfield_id = df_comp.id
+JOIN datasetfieldtype dft_comp ON df_comp.datasetfieldtype_id = dft_comp.id AND dft_comp.name = 'cafeSourceData';
+
+-- Finalmente, eliminar los valores y campos originales
+DELETE FROM datasetfieldvalue WHERE datasetfield_id IN (
+    SELECT df.id FROM datasetfield df JOIN datasetfieldtype dft ON df.datasetfieldtype_id = dft.id
+    WHERE dft.name = 'cafeSourceDataAuthor' AND df.parentdatasetfieldcompoundvalue_id IS NULL
+);
+
+DELETE FROM datasetfield WHERE datasetfieldtype_id = (
+    SELECT id FROM datasetfieldtype WHERE name = 'cafeSourceDataAuthor'
+) AND parentdatasetfieldcompoundvalue_id IS NULL;
+
+
+-- === cafeSourceDataInstitution ===
+INSERT INTO datasetfield (datasetfieldtype_id, parentdatasetfieldcompoundvalue_id)
+SELECT dft_new.id, dfcv.id FROM datasetfield df_comp
+JOIN datasetfieldtype dft_comp ON df_comp.datasetfieldtype_id = dft_comp.id AND dft_comp.name = 'cafeSourceData'
+JOIN datasetfieldcompoundvalue dfcv ON dfcv.parentdatasetfield_id = df_comp.id
+JOIN datasetfield df_old ON df_old.datasetversion_id = df_comp.datasetversion_id
+JOIN datasetfieldtype dft_old ON df_old.datasetfieldtype_id = dft_old.id AND dft_old.name = 'cafeSourceDataInstitution'
+JOIN datasetfieldtype dft_new ON dft_new.name = 'cafeSourceDataInstitution'
+WHERE EXISTS (SELECT 1 FROM datasetfieldvalue dfv WHERE dfv.datasetfield_id = df_old.id);
+INSERT INTO datasetfieldvalue (datasetfield_id, value)
+SELECT df_new.id, dfv.value FROM datasetfield df_new
+JOIN datasetfieldtype dft_new ON df_new.datasetfieldtype_id = dft_new.id AND dft_new.name = 'cafeSourceDataInstitution'
+JOIN datasetfieldcompoundvalue dfcv ON df_new.parentdatasetfieldcompoundvalue_id = dfcv.id
+JOIN datasetfield df_comp ON dfcv.parentdatasetfield_id = df_comp.id
+JOIN datasetfieldtype dft_comp ON df_comp.datasetfieldtype_id = dft_comp.id AND dft_comp.name = 'cafeSourceData'
+JOIN datasetfield df_old ON df_old.datasetversion_id = df_comp.datasetversion_id
+JOIN datasetfieldtype dft_old ON df_old.datasetfieldtype_id = dft_old.id AND dft_old.name = 'cafeSourceDataInstitution'
+JOIN datasetfieldvalue dfv ON dfv.datasetfield_id = df_old.id;
+DELETE FROM datasetfieldvalue WHERE datasetfield_id IN (
+    SELECT df.id FROM datasetfield df JOIN datasetfieldtype dft ON df.datasetfieldtype_id = dft.id
+    WHERE dft.name = 'cafeSourceDataInstitution' AND df.parentdatasetfieldcompoundvalue_id IS NULL
+);
+DELETE FROM datasetfield WHERE datasetfieldtype_id = (
+    SELECT id FROM datasetfieldtype WHERE name = 'cafeSourceDataInstitution'
+) AND parentdatasetfieldcompoundvalue_id IS NULL;
+
+
+-- === cafeSourceDataVersionNumber ===
+INSERT INTO datasetfield (datasetfieldtype_id, parentdatasetfieldcompoundvalue_id)
+SELECT dft_new.id, dfcv.id FROM datasetfield df_comp
+JOIN datasetfieldtype dft_comp ON df_comp.datasetfieldtype_id = dft_comp.id AND dft_comp.name = 'cafeSourceData'
+JOIN datasetfieldcompoundvalue dfcv ON dfcv.parentdatasetfield_id = df_comp.id
+JOIN datasetfield df_old ON df_old.datasetversion_id = df_comp.datasetversion_id
+JOIN datasetfieldtype dft_old ON df_old.datasetfieldtype_id = dft_old.id AND dft_old.name = 'cafeSourceDataVersionNumber'
+JOIN datasetfieldtype dft_new ON dft_new.name = 'cafeSourceDataVersionNumber'
+WHERE EXISTS (SELECT 1 FROM datasetfieldvalue dfv WHERE dfv.datasetfield_id = df_old.id);
+INSERT INTO datasetfieldvalue (datasetfield_id, value)
+SELECT df_new.id, dfv.value FROM datasetfield df_new
+JOIN datasetfieldtype dft_new ON df_new.datasetfieldtype_id = dft_new.id AND dft_new.name = 'cafeSourceDataVersionNumber'
+JOIN datasetfieldcompoundvalue dfcv ON df_new.parentdatasetfieldcompoundvalue_id = dfcv.id
+JOIN datasetfield df_comp ON dfcv.parentdatasetfield_id = df_comp.id
+JOIN datasetfieldtype dft_comp ON df_comp.datasetfieldtype_id = dft_comp.id AND dft_comp.name = 'cafeSourceData'
+JOIN datasetfield df_old ON df_old.datasetversion_id = df_comp.datasetversion_id
+JOIN datasetfieldtype dft_old ON df_old.datasetfieldtype_id = dft_old.id AND dft_old.name = 'cafeSourceDataVersionNumber'
+JOIN datasetfieldvalue dfv ON dfv.datasetfield_id = df_old.id;
+DELETE FROM datasetfieldvalue WHERE datasetfield_id IN (
+    SELECT df.id FROM datasetfield df JOIN datasetfieldtype dft ON df.datasetfieldtype_id = dft.id
+    WHERE dft.name = 'cafeSourceDataVersionNumber' AND df.parentdatasetfieldcompoundvalue_id IS NULL
+);
+DELETE FROM datasetfield WHERE datasetfieldtype_id = (
+    SELECT id FROM datasetfieldtype WHERE name = 'cafeSourceDataVersionNumber'
+) AND parentdatasetfieldcompoundvalue_id IS NULL;
+
+
+-- === cafeSourceDataDOIOrURL ===
+INSERT INTO datasetfield (datasetfieldtype_id, parentdatasetfieldcompoundvalue_id)
+SELECT dft_new.id, dfcv.id FROM datasetfield df_comp
+JOIN datasetfieldtype dft_comp ON df_comp.datasetfieldtype_id = dft_comp.id AND dft_comp.name = 'cafeSourceData'
+JOIN datasetfieldcompoundvalue dfcv ON dfcv.parentdatasetfield_id = df_comp.id
+JOIN datasetfield df_old ON df_old.datasetversion_id = df_comp.datasetversion_id
+JOIN datasetfieldtype dft_old ON df_old.datasetfieldtype_id = dft_old.id AND dft_old.name = 'cafeSourceDataDOIOrURL'
+JOIN datasetfieldtype dft_new ON dft_new.name = 'cafeSourceDataDOIOrURL'
+WHERE EXISTS (SELECT 1 FROM datasetfieldvalue dfv WHERE dfv.datasetfield_id = df_old.id);
+INSERT INTO datasetfieldvalue (datasetfield_id, value)
+SELECT df_new.id, dfv.value FROM datasetfield df_new
+JOIN datasetfieldtype dft_new ON df_new.datasetfieldtype_id = dft_new.id AND dft_new.name = 'cafeSourceDataDOIOrURL'
+JOIN datasetfieldcompoundvalue dfcv ON df_new.parentdatasetfieldcompoundvalue_id = dfcv.id
+JOIN datasetfield df_comp ON dfcv.parentdatasetfield_id = df_comp.id
+JOIN datasetfieldtype dft_comp ON df_comp.datasetfieldtype_id = dft_comp.id AND dft_comp.name = 'cafeSourceData'
+JOIN datasetfield df_old ON df_old.datasetversion_id = df_comp.datasetversion_id
+JOIN datasetfieldtype dft_old ON df_old.datasetfieldtype_id = dft_old.id AND dft_old.name = 'cafeSourceDataDOIOrURL'
+JOIN datasetfieldvalue dfv ON dfv.datasetfield_id = df_old.id;
+DELETE FROM datasetfieldvalue WHERE datasetfield_id IN (
+    SELECT df.id FROM datasetfield df JOIN datasetfieldtype dft ON df.datasetfieldtype_id = dft.id
+    WHERE dft.name = 'cafeSourceDataDOIOrURL' AND df.parentdatasetfieldcompoundvalue_id IS NULL
+);
+DELETE FROM datasetfield WHERE datasetfieldtype_id = (
+    SELECT id FROM datasetfieldtype WHERE name = 'cafeSourceDataDOIOrURL'
+) AND parentdatasetfieldcompoundvalue_id IS NULL;
+
+
+-- === cafeSourceDataLastModifiedDate ===
+INSERT INTO datasetfield (datasetfieldtype_id, parentdatasetfieldcompoundvalue_id)
+SELECT dft_new.id, dfcv.id FROM datasetfield df_comp
+JOIN datasetfieldtype dft_comp ON df_comp.datasetfieldtype_id = dft_comp.id AND dft_comp.name = 'cafeSourceData'
+JOIN datasetfieldcompoundvalue dfcv ON dfcv.parentdatasetfield_id = df_comp.id
+JOIN datasetfield df_old ON df_old.datasetversion_id = df_comp.datasetversion_id
+JOIN datasetfieldtype dft_old ON df_old.datasetfieldtype_id = dft_old.id AND dft_old.name = 'cafeSourceDataLastModifiedDate'
+JOIN datasetfieldtype dft_new ON dft_new.name = 'cafeSourceDataLastModifiedDate'
+WHERE EXISTS (SELECT 1 FROM datasetfieldvalue dfv WHERE dfv.datasetfield_id = df_old.id);
+INSERT INTO datasetfieldvalue (datasetfield_id, value)
+SELECT df_new.id, dfv.value FROM datasetfield df_new
+JOIN datasetfieldtype dft_new ON df_new.datasetfieldtype_id = dft_new.id AND dft_new.name = 'cafeSourceDataLastModifiedDate'
+JOIN datasetfieldcompoundvalue dfcv ON df_new.parentdatasetfieldcompoundvalue_id = dfcv.id
+JOIN datasetfield df_comp ON dfcv.parentdatasetfield_id = df_comp.id
+JOIN datasetfieldtype dft_comp ON df_comp.datasetfieldtype_id = dft_comp.id AND dft_comp.name = 'cafeSourceData'
+JOIN datasetfield df_old ON df_old.datasetversion_id = df_comp.datasetversion_id
+JOIN datasetfieldtype dft_old ON df_old.datasetfieldtype_id = dft_old.id AND dft_old.name = 'cafeSourceDataLastModifiedDate'
+JOIN datasetfieldvalue dfv ON dfv.datasetfield_id = df_old.id;
+DELETE FROM datasetfieldvalue WHERE datasetfield_id IN (
+    SELECT df.id FROM datasetfield df JOIN datasetfieldtype dft ON df.datasetfieldtype_id = dft.id
+    WHERE dft.name = 'cafeSourceDataLastModifiedDate' AND df.parentdatasetfieldcompoundvalue_id IS NULL
+);
+DELETE FROM datasetfield WHERE datasetfieldtype_id = (
+    SELECT id FROM datasetfieldtype WHERE name = 'cafeSourceDataLastModifiedDate'
+) AND parentdatasetfieldcompoundvalue_id IS NULL;
+
+
+-- === cafeSourceDataDateObtained ===
+INSERT INTO datasetfield (datasetfieldtype_id, parentdatasetfieldcompoundvalue_id)
+SELECT dft_new.id, dfcv.id FROM datasetfield df_comp
+JOIN datasetfieldtype dft_comp ON df_comp.datasetfieldtype_id = dft_comp.id AND dft_comp.name = 'cafeSourceData'
+JOIN datasetfieldcompoundvalue dfcv ON dfcv.parentdatasetfield_id = df_comp.id
+JOIN datasetfield df_old ON df_old.datasetversion_id = df_comp.datasetversion_id
+JOIN datasetfieldtype dft_old ON df_old.datasetfieldtype_id = dft_old.id AND dft_old.name = 'cafeSourceDataDateObtained'
+JOIN datasetfieldtype dft_new ON dft_new.name = 'cafeSourceDataDateObtained'
+WHERE EXISTS (SELECT 1 FROM datasetfieldvalue dfv WHERE dfv.datasetfield_id = df_old.id);
+INSERT INTO datasetfieldvalue (datasetfield_id, value)
+SELECT df_new.id, dfv.value FROM datasetfield df_new
+JOIN datasetfieldtype dft_new ON df_new.datasetfieldtype_id = dft_new.id AND dft_new.name = 'cafeSourceDataDateObtained'
+JOIN datasetfieldcompoundvalue dfcv ON df_new.parentdatasetfieldcompoundvalue_id = dfcv.id
+JOIN datasetfield df_comp ON dfcv.parentdatasetfield_id = df_comp.id
+JOIN datasetfieldtype dft_comp ON df_comp.datasetfieldtype_id = dft_comp.id AND dft_comp.name = 'cafeSourceData'
+JOIN datasetfield df_old ON df_old.datasetversion_id = df_comp.datasetversion_id
+JOIN datasetfieldtype dft_old ON df_old.datasetfieldtype_id = dft_old.id AND dft_old.name = 'cafeSourceDataDateObtained'
+JOIN datasetfieldvalue dfv ON dfv.datasetfield_id = df_old.id;
+DELETE FROM datasetfieldvalue WHERE datasetfield_id IN (
+    SELECT df.id FROM datasetfield df JOIN datasetfieldtype dft ON df.datasetfieldtype_id = dft.id
+    WHERE dft.name = 'cafeSourceDataDateObtained' AND df.parentdatasetfieldcompoundvalue_id IS NULL
+);
+DELETE FROM datasetfield WHERE datasetfieldtype_id = (
+    SELECT id FROM datasetfieldtype WHERE name = 'cafeSourceDataDateObtained'
+) AND parentdatasetfieldcompoundvalue_id IS NULL;
+
+
+-- === cafeSourceDataType ===
+-- Crear campos compuestos para cada dataset que tenga valores de tipo
+INSERT INTO datasetfield (datasetfieldtype_id, parentdatasetfieldcompoundvalue_id)
+SELECT DISTINCT dft_new.id, dfcv.id 
+FROM datasetfield df_comp
+JOIN datasetfieldtype dft_comp ON df_comp.datasetfieldtype_id = dft_comp.id AND dft_comp.name = 'cafeSourceData'
+JOIN datasetfieldcompoundvalue dfcv ON dfcv.parentdatasetfield_id = df_comp.id
+JOIN datasetfield df_old ON df_old.datasetversion_id = df_comp.datasetversion_id
+JOIN datasetfieldtype dft_old ON df_old.datasetfieldtype_id = dft_old.id AND dft_old.name = 'cafeSourceDataType'
+JOIN datasetfieldtype dft_new ON dft_new.name = 'cafeSourceDataType'
+WHERE EXISTS (
+    SELECT 1 FROM datasetfield_controlledvocabularyvalue dfcv2 
+    WHERE dfcv2.datasetfield_id = df_old.id
+)
+AND NOT EXISTS (
+    SELECT 1 FROM datasetfield df_new2
+    JOIN datasetfieldtype dft_new2 ON df_new2.datasetfieldtype_id = dft_new2.id AND dft_new2.name = 'cafeSourceDataType'
+    WHERE df_new2.parentdatasetfieldcompoundvalue_id = dfcv.id
+);
+
+-- Copiar los valores de vocabulario controlado
+INSERT INTO datasetfield_controlledvocabularyvalue (datasetfield_id, controlledvocabularyvalues_id)
+SELECT df_new.id, dfcv2.controlledvocabularyvalues_id
+FROM datasetfield df_new
+JOIN datasetfieldtype dft_new ON df_new.datasetfieldtype_id = dft_new.id AND dft_new.name = 'cafeSourceDataType'
+JOIN datasetfieldcompoundvalue dfcv ON df_new.parentdatasetfieldcompoundvalue_id = dfcv.id
+JOIN datasetfield df_comp ON dfcv.parentdatasetfield_id = df_comp.id
+JOIN datasetfieldtype dft_comp ON df_comp.datasetfieldtype_id = dft_comp.id AND dft_comp.name = 'cafeSourceData'
+JOIN datasetfield df_old ON df_old.datasetversion_id = df_comp.datasetversion_id
+JOIN datasetfieldtype dft_old ON df_old.datasetfieldtype_id = dft_old.id AND dft_old.name = 'cafeSourceDataType'
+JOIN datasetfield_controlledvocabularyvalue dfcv2 ON dfcv2.datasetfield_id = df_old.id;
+
+-- Eliminar las referencias en datasetfield_controlledvocabularyvalue
+DELETE FROM datasetfield_controlledvocabularyvalue 
+WHERE datasetfield_id IN (
+    SELECT df.id FROM datasetfield df 
+    JOIN datasetfieldtype dft ON df.datasetfieldtype_id = dft.id
+    WHERE dft.name = 'cafeSourceDataType' AND df.parentdatasetfieldcompoundvalue_id IS NULL
+);
+
+-- Eliminar los campos antiguos
+DELETE FROM datasetfield 
+WHERE datasetfieldtype_id = (
+    SELECT id FROM datasetfieldtype WHERE name = 'cafeSourceDataType'
+) AND parentdatasetfieldcompoundvalue_id IS NULL;
+
+
+-- === cafeSourceDataTypeOther ===
+INSERT INTO datasetfield (datasetfieldtype_id, parentdatasetfieldcompoundvalue_id)
+SELECT dft_new.id, dfcv.id FROM datasetfield df_comp
+JOIN datasetfieldtype dft_comp ON df_comp.datasetfieldtype_id = dft_comp.id AND dft_comp.name = 'cafeSourceData'
+JOIN datasetfieldcompoundvalue dfcv ON dfcv.parentdatasetfield_id = df_comp.id
+JOIN datasetfield df_old ON df_old.datasetversion_id = df_comp.datasetversion_id
+JOIN datasetfieldtype dft_old ON df_old.datasetfieldtype_id = dft_old.id AND dft_old.name = 'cafeSourceDataTypeOther'
+JOIN datasetfieldtype dft_new ON dft_new.name = 'cafeSourceDataTypeOther'
+WHERE EXISTS (SELECT 1 FROM datasetfieldvalue dfv WHERE dfv.datasetfield_id = df_old.id);
+INSERT INTO datasetfieldvalue (datasetfield_id, value)
+SELECT df_new.id, dfv.value FROM datasetfield df_new
+JOIN datasetfieldtype dft_new ON df_new.datasetfieldtype_id = dft_new.id AND dft_new.name = 'cafeSourceDataTypeOther'
+JOIN datasetfieldcompoundvalue dfcv ON df_new.parentdatasetfieldcompoundvalue_id = dfcv.id
+JOIN datasetfield df_comp ON dfcv.parentdatasetfield_id = df_comp.id
+JOIN datasetfieldtype dft_comp ON df_comp.datasetfieldtype_id = dft_comp.id AND dft_comp.name = 'cafeSourceData'
+JOIN datasetfield df_old ON df_old.datasetversion_id = df_comp.datasetversion_id
+JOIN datasetfieldtype dft_old ON df_old.datasetfieldtype_id = dft_old.id AND dft_old.name = 'cafeSourceDataTypeOther'
+JOIN datasetfieldvalue dfv ON dfv.datasetfield_id = df_old.id;
+DELETE FROM datasetfieldvalue WHERE datasetfield_id IN (
+    SELECT df.id FROM datasetfield df JOIN datasetfieldtype dft ON df.datasetfieldtype_id = dft.id
+    WHERE dft.name = 'cafeSourceDataTypeOther' AND df.parentdatasetfieldcompoundvalue_id IS NULL
+);
+DELETE FROM datasetfield WHERE datasetfieldtype_id = (
+    SELECT id FROM datasetfieldtype WHERE name = 'cafeSourceDataTypeOther'
+) AND parentdatasetfieldcompoundvalue_id IS NULL;
+
+
+-- === cafeSourceDataSpatialResolution ===
+-- Crear campos compuestos para cada dataset que tenga valores de spatial resolution
+INSERT INTO datasetfield (datasetfieldtype_id, parentdatasetfieldcompoundvalue_id)
+SELECT DISTINCT dft_new.id, dfcv.id 
+FROM datasetfield df_comp
+JOIN datasetfieldtype dft_comp ON df_comp.datasetfieldtype_id = dft_comp.id AND dft_comp.name = 'cafeSourceData'
+JOIN datasetfieldcompoundvalue dfcv ON dfcv.parentdatasetfield_id = df_comp.id
+JOIN datasetfield df_old ON df_old.datasetversion_id = df_comp.datasetversion_id
+JOIN datasetfieldtype dft_old ON df_old.datasetfieldtype_id = dft_old.id AND dft_old.name = 'cafeSourceDataSpatialResolution'
+JOIN datasetfieldtype dft_new ON dft_new.name = 'cafeSourceDataSpatialResolution'
+WHERE EXISTS (
+    SELECT 1 FROM datasetfield df_sub
+    JOIN datasetfieldtype dft_sub ON df_sub.datasetfieldtype_id = dft_sub.id
+    WHERE dft_sub.name IN ('cafeSourceDataSpatialValue', 'cafeSourceDataSpatialResolutionUnit', 'cafeSourceDataSpatialResolutionUnitOther')
+    AND df_sub.parentdatasetfieldcompoundvalue_id IN (
+        SELECT dfcv2.id FROM datasetfieldcompoundvalue dfcv2
+        JOIN datasetfield df_parent ON dfcv2.parentdatasetfield_id = df_parent.id
+        WHERE df_parent.id = df_old.id
+    )
+)
+AND NOT EXISTS (
+    SELECT 1 FROM datasetfield df_new2
+    JOIN datasetfieldtype dft_new2 ON df_new2.datasetfieldtype_id = dft_new2.id AND dft_new2.name = 'cafeSourceDataSpatialResolution'
+    WHERE df_new2.parentdatasetfieldcompoundvalue_id = dfcv.id
+);
+
+-- === cafeSourceDataSpatialResolutionUnit ===
+-- Crear campos compuestos para cada dataset que tenga valores de spatial resolution unit
+INSERT INTO datasetfield (datasetfieldtype_id, parentdatasetfieldcompoundvalue_id)
+SELECT DISTINCT dft_new.id, dfcv.id 
+FROM datasetfield df_comp
+JOIN datasetfieldtype dft_comp ON df_comp.datasetfieldtype_id = dft_comp.id AND dft_comp.name = 'cafeSourceData'
+JOIN datasetfieldcompoundvalue dfcv ON dfcv.parentdatasetfield_id = df_comp.id
+JOIN datasetfield df_old ON df_old.datasetversion_id = df_comp.datasetversion_id
+JOIN datasetfieldtype dft_old ON df_old.datasetfieldtype_id = dft_old.id AND dft_old.name = 'cafeSourceDataSpatialResolution'
+JOIN datasetfieldtype dft_new ON dft_new.name = 'cafeSourceDataSpatialResolutionUnit'
+WHERE EXISTS (
+    SELECT 1 FROM datasetfield df_sub
+    JOIN datasetfieldtype dft_sub ON df_sub.datasetfieldtype_id = dft_sub.id
+    WHERE dft_sub.name = 'cafeSourceDataSpatialResolutionUnit'
+    AND df_sub.parentdatasetfieldcompoundvalue_id IN (
+        SELECT dfcv2.id FROM datasetfieldcompoundvalue dfcv2
+        JOIN datasetfield df_parent ON dfcv2.parentdatasetfield_id = df_parent.id
+        WHERE df_parent.id = df_old.id
+    )
+)
+AND NOT EXISTS (
+    SELECT 1 FROM datasetfield df_new2
+    JOIN datasetfieldtype dft_new2 ON df_new2.datasetfieldtype_id = dft_new2.id AND dft_new2.name = 'cafeSourceDataSpatialResolutionUnit'
+    WHERE df_new2.parentdatasetfieldcompoundvalue_id = dfcv.id
+);
+
+-- === cafeSourceDataSpatialResolutionUnitOther ===
+-- Crear campos compuestos para cada dataset que tenga valores de spatial resolution unit other
+INSERT INTO datasetfield (datasetfieldtype_id, parentdatasetfieldcompoundvalue_id)
+SELECT DISTINCT dft_new.id, dfcv.id 
+FROM datasetfield df_comp
+JOIN datasetfieldtype dft_comp ON df_comp.datasetfieldtype_id = dft_comp.id AND dft_comp.name = 'cafeSourceData'
+JOIN datasetfieldcompoundvalue dfcv ON dfcv.parentdatasetfield_id = df_comp.id
+JOIN datasetfield df_old ON df_old.datasetversion_id = df_comp.datasetversion_id
+JOIN datasetfieldtype dft_old ON df_old.datasetfieldtype_id = dft_old.id AND dft_old.name = 'cafeSourceDataSpatialResolution'
+JOIN datasetfieldtype dft_new ON dft_new.name = 'cafeSourceDataSpatialResolutionUnitOther'
+WHERE EXISTS (
+    SELECT 1 FROM datasetfield df_sub
+    JOIN datasetfieldtype dft_sub ON df_sub.datasetfieldtype_id = dft_sub.id
+    WHERE dft_sub.name = 'cafeSourceDataSpatialResolutionUnitOther'
+    AND df_sub.parentdatasetfieldcompoundvalue_id IN (
+        SELECT dfcv2.id FROM datasetfieldcompoundvalue dfcv2
+        JOIN datasetfield df_parent ON dfcv2.parentdatasetfield_id = df_parent.id
+        WHERE df_parent.id = df_old.id
+    )
+)
+AND NOT EXISTS (
+    SELECT 1 FROM datasetfield df_new2
+    JOIN datasetfieldtype dft_new2 ON df_new2.datasetfieldtype_id = dft_new2.id AND dft_new2.name = 'cafeSourceDataSpatialResolutionUnitOther'
+    WHERE df_new2.parentdatasetfieldcompoundvalue_id = dfcv.id
+);
+
+-- Migrar valores de cafeSourceDataSpatialValue a cafeSourceDataSpatialResolution
+INSERT INTO datasetfieldvalue (datasetfield_id, value)
+SELECT df_new.id, dfv.value
+FROM datasetfield df_new
+JOIN datasetfieldtype dft_new ON df_new.datasetfieldtype_id = dft_new.id AND dft_new.name = 'cafeSourceDataSpatialResolution'
+JOIN datasetfieldcompoundvalue dfcv ON df_new.parentdatasetfieldcompoundvalue_id = dfcv.id
+JOIN datasetfield df_comp ON dfcv.parentdatasetfield_id = df_comp.id
+JOIN datasetfieldtype dft_comp ON df_comp.datasetfieldtype_id = dft_comp.id AND dft_comp.name = 'cafeSourceData'
+JOIN datasetfield df_old ON df_old.datasetversion_id = df_comp.datasetversion_id
+JOIN datasetfieldtype dft_old ON df_old.datasetfieldtype_id = dft_old.id AND dft_old.name = 'cafeSourceDataSpatialResolution'
+JOIN datasetfieldcompoundvalue dfcv_parent ON dfcv_parent.parentdatasetfield_id = df_old.id
+JOIN datasetfield df_sub ON df_sub.parentdatasetfieldcompoundvalue_id = dfcv_parent.id
+JOIN datasetfieldtype dft_sub ON df_sub.datasetfieldtype_id = dft_sub.id AND dft_sub.name = 'cafeSourceDataSpatialValue'
+JOIN datasetfieldvalue dfv ON dfv.datasetfield_id = df_sub.id;
+
+-- Migrar valores de cafeSourceDataSpatialResolutionUnit a cafeSourceDataSpatialResolutionUnit
+-- Primero los valores de vocabulario controlado
+INSERT INTO datasetfield_controlledvocabularyvalue (datasetfield_id, controlledvocabularyvalues_id)
+SELECT df_new.id, dfcv2.controlledvocabularyvalues_id
+FROM datasetfield df_new
+JOIN datasetfieldtype dft_new ON df_new.datasetfieldtype_id = dft_new.id AND dft_new.name = 'cafeSourceDataSpatialResolutionUnit'
+JOIN datasetfieldcompoundvalue dfcv ON df_new.parentdatasetfieldcompoundvalue_id = dfcv.id
+JOIN datasetfield df_comp ON dfcv.parentdatasetfield_id = df_comp.id
+JOIN datasetfieldtype dft_comp ON df_comp.datasetfieldtype_id = dft_comp.id AND dft_comp.name = 'cafeSourceData'
+JOIN datasetfield df_old ON df_old.datasetversion_id = df_comp.datasetversion_id
+JOIN datasetfieldtype dft_old ON df_old.datasetfieldtype_id = dft_old.id AND dft_old.name = 'cafeSourceDataSpatialResolution'
+JOIN datasetfieldcompoundvalue dfcv_parent ON dfcv_parent.parentdatasetfield_id = df_old.id
+JOIN datasetfield df_sub ON df_sub.parentdatasetfieldcompoundvalue_id = dfcv_parent.id
+JOIN datasetfieldtype dft_sub ON df_sub.datasetfieldtype_id = dft_sub.id AND dft_sub.name = 'cafeSourceDataSpatialResolutionUnit'
+JOIN datasetfield_controlledvocabularyvalue dfcv2 ON dfcv2.datasetfield_id = df_sub.id;
+
+-- Luego los valores normales
+INSERT INTO datasetfieldvalue (datasetfield_id, value)
+SELECT df_new.id, dfv.value
+FROM datasetfield df_new
+JOIN datasetfieldtype dft_new ON df_new.datasetfieldtype_id = dft_new.id AND dft_new.name = 'cafeSourceDataSpatialResolutionUnit'
+JOIN datasetfieldcompoundvalue dfcv ON df_new.parentdatasetfieldcompoundvalue_id = dfcv.id
+JOIN datasetfield df_comp ON dfcv.parentdatasetfield_id = df_comp.id
+JOIN datasetfieldtype dft_comp ON df_comp.datasetfieldtype_id = dft_comp.id AND dft_comp.name = 'cafeSourceData'
+JOIN datasetfield df_old ON df_old.datasetversion_id = df_comp.datasetversion_id
+JOIN datasetfieldtype dft_old ON df_old.datasetfieldtype_id = dft_old.id AND dft_old.name = 'cafeSourceDataSpatialResolution'
+JOIN datasetfieldcompoundvalue dfcv_parent ON dfcv_parent.parentdatasetfield_id = df_old.id
+JOIN datasetfield df_sub ON df_sub.parentdatasetfieldcompoundvalue_id = dfcv_parent.id
+JOIN datasetfieldtype dft_sub ON df_sub.datasetfieldtype_id = dft_sub.id AND dft_sub.name = 'cafeSourceDataSpatialResolutionUnit'
+JOIN datasetfieldvalue dfv ON dfv.datasetfield_id = df_sub.id
+WHERE NOT EXISTS (
+    SELECT 1 FROM datasetfield_controlledvocabularyvalue dfcv2 
+    WHERE dfcv2.datasetfield_id = df_sub.id
+);
+
+-- Migrar valores de cafeSourceDataSpatialResolutionUnitOther a cafeSourceDataSpatialResolutionUnitOther
+INSERT INTO datasetfieldvalue (datasetfield_id, value)
+SELECT df_new.id, dfv.value
+FROM datasetfield df_new
+JOIN datasetfieldtype dft_new ON df_new.datasetfieldtype_id = dft_new.id AND dft_new.name = 'cafeSourceDataSpatialResolutionUnitOther'
+JOIN datasetfieldcompoundvalue dfcv ON df_new.parentdatasetfieldcompoundvalue_id = dfcv.id
+JOIN datasetfield df_comp ON dfcv.parentdatasetfield_id = df_comp.id
+JOIN datasetfieldtype dft_comp ON df_comp.datasetfieldtype_id = dft_comp.id AND dft_comp.name = 'cafeSourceData'
+JOIN datasetfield df_old ON df_old.datasetversion_id = df_comp.datasetversion_id
+JOIN datasetfieldtype dft_old ON df_old.datasetfieldtype_id = dft_old.id AND dft_old.name = 'cafeSourceDataSpatialResolution'
+JOIN datasetfieldcompoundvalue dfcv_parent ON dfcv_parent.parentdatasetfield_id = df_old.id
+JOIN datasetfield df_sub ON df_sub.parentdatasetfieldcompoundvalue_id = dfcv_parent.id
+JOIN datasetfieldtype dft_sub ON df_sub.datasetfieldtype_id = dft_sub.id AND dft_sub.name = 'cafeSourceDataSpatialResolutionUnitOther'
+JOIN datasetfieldvalue dfv ON dfv.datasetfield_id = df_sub.id;
+
+-- Eliminar los valores y campos antiguos en el orden correcto
+-- Primero eliminar las referencias en datasetfield_controlledvocabularyvalue para los subcampos
+DELETE FROM datasetfield_controlledvocabularyvalue 
+WHERE datasetfield_id IN (
+    SELECT df.id FROM datasetfield df 
+    JOIN datasetfieldtype dft ON df.datasetfieldtype_id = dft.id
+    WHERE dft.name = 'cafeSourceDataSpatialResolutionUnit' 
+    AND df.parentdatasetfieldcompoundvalue_id IN (
+        SELECT dfcv.id FROM datasetfieldcompoundvalue dfcv
+        JOIN datasetfield df_parent ON dfcv.parentdatasetfield_id = df_parent.id
+        JOIN datasetfieldtype dft_parent ON df_parent.datasetfieldtype_id = dft_parent.id
+        WHERE dft_parent.name = 'cafeSourceDataSpatialResolution'
+    )
+);
+
+-- Luego eliminar los valores en datasetfieldvalue para los subcampos
+DELETE FROM datasetfieldvalue 
+WHERE datasetfield_id IN (
+    SELECT df.id FROM datasetfield df 
+    JOIN datasetfieldtype dft ON df.datasetfieldtype_id = dft.id
+    WHERE dft.name IN ('cafeSourceDataSpatialValue', 'cafeSourceDataSpatialResolutionUnit', 'cafeSourceDataSpatialResolutionUnitOther')
+    AND df.parentdatasetfieldcompoundvalue_id IN (
+        SELECT dfcv.id FROM datasetfieldcompoundvalue dfcv
+        JOIN datasetfield df_parent ON dfcv.parentdatasetfield_id = df_parent.id
+        JOIN datasetfieldtype dft_parent ON df_parent.datasetfieldtype_id = dft_parent.id
+        WHERE dft_parent.name = 'cafeSourceDataSpatialResolution'
+    )
+);
+
+-- Eliminar las referencias en datasetfieldcompoundvalue para los subcampos
+DELETE FROM datasetfieldcompoundvalue
+WHERE parentdatasetfield_id IN (
+    SELECT df.id FROM datasetfield df 
+    JOIN datasetfieldtype dft ON df.datasetfieldtype_id = dft.id
+    WHERE dft.name IN ('cafeSourceDataSpatialValue', 'cafeSourceDataSpatialResolutionUnit', 'cafeSourceDataSpatialResolutionUnitOther')
+    AND df.parentdatasetfieldcompoundvalue_id IN (
+        SELECT dfcv.id FROM datasetfieldcompoundvalue dfcv
+        JOIN datasetfield df_parent ON dfcv.parentdatasetfield_id = df_parent.id
+        JOIN datasetfieldtype dft_parent ON df_parent.datasetfieldtype_id = dft_parent.id
+        WHERE dft_parent.name = 'cafeSourceDataSpatialResolution'
+    )
+);
+
+-- Finalmente eliminar los campos subcampos
+DELETE FROM datasetfield 
+WHERE datasetfieldtype_id IN (
+    SELECT id FROM datasetfieldtype 
+    WHERE name IN ('cafeSourceDataSpatialValue', 'cafeSourceDataSpatialResolutionUnit', 'cafeSourceDataSpatialResolutionUnitOther')
+)
+AND parentdatasetfieldcompoundvalue_id IN (
+    SELECT dfcv.id FROM datasetfieldcompoundvalue dfcv
+    JOIN datasetfield df_parent ON dfcv.parentdatasetfield_id = df_parent.id
+    JOIN datasetfieldtype dft_parent ON df_parent.datasetfieldtype_id = dft_parent.id
+    WHERE dft_parent.name = 'cafeSourceDataSpatialResolution'
+);
+
+-- Eliminar las referencias en datasetfieldcompoundvalue para el campo padre
+DELETE FROM datasetfieldcompoundvalue
+WHERE parentdatasetfield_id IN (
+    SELECT df.id FROM datasetfield df 
+    JOIN datasetfieldtype dft ON df.datasetfieldtype_id = dft.id
+    WHERE dft.name = 'cafeSourceDataSpatialResolution'
+    AND df.parentdatasetfieldcompoundvalue_id IS NULL
+);
+
+-- Finalmente eliminar el campo padre
+DELETE FROM datasetfield 
+WHERE datasetfieldtype_id = (
+    SELECT id FROM datasetfieldtype WHERE name = 'cafeSourceDataSpatialResolution'
+) AND parentdatasetfieldcompoundvalue_id IS NULL;
+
+
+-- === cafeSourceDataTimestep ===
+-- Crear campos compuestos para cada dataset que tenga valores de timestep
+INSERT INTO datasetfield (datasetfieldtype_id, parentdatasetfieldcompoundvalue_id)
+SELECT DISTINCT dft_new.id, dfcv.id 
+FROM datasetfield df_comp
+JOIN datasetfieldtype dft_comp ON df_comp.datasetfieldtype_id = dft_comp.id AND dft_comp.name = 'cafeSourceData'
+JOIN datasetfieldcompoundvalue dfcv ON dfcv.parentdatasetfield_id = df_comp.id
+JOIN datasetfield df_old ON df_old.datasetversion_id = df_comp.datasetversion_id
+JOIN datasetfieldtype dft_old ON df_old.datasetfieldtype_id = dft_old.id AND dft_old.name = 'cafeSourceDataTimestep'
+JOIN datasetfieldtype dft_new ON dft_new.name = 'cafeSourceDataTimestep'
+WHERE EXISTS (
+    SELECT 1 FROM datasetfield_controlledvocabularyvalue dfcv2 
+    WHERE dfcv2.datasetfield_id = df_old.id
+)
+AND NOT EXISTS (
+    SELECT 1 FROM datasetfield df_new2
+    JOIN datasetfieldtype dft_new2 ON df_new2.datasetfieldtype_id = dft_new2.id AND dft_new2.name = 'cafeSourceDataTimestep'
+    WHERE df_new2.parentdatasetfieldcompoundvalue_id = dfcv.id
+);
+
+-- Copiar los valores de vocabulario controlado
+INSERT INTO datasetfield_controlledvocabularyvalue (datasetfield_id, controlledvocabularyvalues_id)
+SELECT df_new.id, dfcv2.controlledvocabularyvalues_id
+FROM datasetfield df_new
+JOIN datasetfieldtype dft_new ON df_new.datasetfieldtype_id = dft_new.id AND dft_new.name = 'cafeSourceDataTimestep'
+JOIN datasetfieldcompoundvalue dfcv ON df_new.parentdatasetfieldcompoundvalue_id = dfcv.id
+JOIN datasetfield df_comp ON dfcv.parentdatasetfield_id = df_comp.id
+JOIN datasetfieldtype dft_comp ON df_comp.datasetfieldtype_id = dft_comp.id AND dft_comp.name = 'cafeSourceData'
+JOIN datasetfield df_old ON df_old.datasetversion_id = df_comp.datasetversion_id
+JOIN datasetfieldtype dft_old ON df_old.datasetfieldtype_id = dft_old.id AND dft_old.name = 'cafeSourceDataTimestep'
+JOIN datasetfield_controlledvocabularyvalue dfcv2 ON dfcv2.datasetfield_id = df_old.id;
+
+-- Eliminar las referencias en datasetfield_controlledvocabularyvalue
+DELETE FROM datasetfield_controlledvocabularyvalue 
+WHERE datasetfield_id IN (
+    SELECT df.id FROM datasetfield df 
+    JOIN datasetfieldtype dft ON df.datasetfieldtype_id = dft.id
+    WHERE dft.name = 'cafeSourceDataTimestep' AND df.parentdatasetfieldcompoundvalue_id IS NULL
+);
+
+-- Eliminar los campos antiguos
+DELETE FROM datasetfield 
+WHERE datasetfieldtype_id = (
+    SELECT id FROM datasetfieldtype WHERE name = 'cafeSourceDataTimestep'
+) AND parentdatasetfieldcompoundvalue_id IS NULL;
+
+
+-- === cafeSourceDataTimestepOther ===
+INSERT INTO datasetfield (datasetfieldtype_id, parentdatasetfieldcompoundvalue_id)
+SELECT dft_new.id, dfcv.id FROM datasetfield df_comp
+JOIN datasetfieldtype dft_comp ON df_comp.datasetfieldtype_id = dft_comp.id AND dft_comp.name = 'cafeSourceData'
+JOIN datasetfieldcompoundvalue dfcv ON dfcv.parentdatasetfield_id = df_comp.id
+JOIN datasetfield df_old ON df_old.datasetversion_id = df_comp.datasetversion_id
+JOIN datasetfieldtype dft_old ON df_old.datasetfieldtype_id = dft_old.id AND dft_old.name = 'cafeSourceDataTimestepOther'
+JOIN datasetfieldtype dft_new ON dft_new.name = 'cafeSourceDataTimestepOther'
+WHERE EXISTS (SELECT 1 FROM datasetfieldvalue dfv WHERE dfv.datasetfield_id = df_old.id);
+INSERT INTO datasetfieldvalue (datasetfield_id, value)
+SELECT df_new.id, dfv.value FROM datasetfield df_new
+JOIN datasetfieldtype dft_new ON df_new.datasetfieldtype_id = dft_new.id AND dft_new.name = 'cafeSourceDataTimestepOther'
+JOIN datasetfieldcompoundvalue dfcv ON df_new.parentdatasetfieldcompoundvalue_id = dfcv.id
+JOIN datasetfield df_comp ON dfcv.parentdatasetfield_id = df_comp.id
+JOIN datasetfieldtype dft_comp ON df_comp.datasetfieldtype_id = dft_comp.id AND dft_comp.name = 'cafeSourceData'
+JOIN datasetfield df_old ON df_old.datasetversion_id = df_comp.datasetversion_id
+JOIN datasetfieldtype dft_old ON df_old.datasetfieldtype_id = dft_old.id AND dft_old.name = 'cafeSourceDataTimestepOther'
+JOIN datasetfieldvalue dfv ON dfv.datasetfield_id = df_old.id;
+DELETE FROM datasetfieldvalue WHERE datasetfield_id IN (
+    SELECT df.id FROM datasetfield df JOIN datasetfieldtype dft ON df.datasetfieldtype_id = dft.id
+    WHERE dft.name = 'cafeSourceDataTimestepOther' AND df.parentdatasetfieldcompoundvalue_id IS NULL
+);
+DELETE FROM datasetfield WHERE datasetfieldtype_id = (
+    SELECT id FROM datasetfieldtype WHERE name = 'cafeSourceDataTimestepOther'
+) AND parentdatasetfieldcompoundvalue_id IS NULL;
+
+
+-- === cafeSourceDataAttribution ===
+INSERT INTO datasetfield (datasetfieldtype_id, parentdatasetfieldcompoundvalue_id)
+SELECT dft_new.id, dfcv.id FROM datasetfield df_comp
+JOIN datasetfieldtype dft_comp ON df_comp.datasetfieldtype_id = dft_comp.id AND dft_comp.name = 'cafeSourceData'
+JOIN datasetfieldcompoundvalue dfcv ON dfcv.parentdatasetfield_id = df_comp.id
+JOIN datasetfield df_old ON df_old.datasetversion_id = df_comp.datasetversion_id
+JOIN datasetfieldtype dft_old ON df_old.datasetfieldtype_id = dft_old.id AND dft_old.name = 'cafeSourceDataAttribution'
+JOIN datasetfieldtype dft_new ON dft_new.name = 'cafeSourceDataAttribution'
+WHERE EXISTS (SELECT 1 FROM datasetfieldvalue dfv WHERE dfv.datasetfield_id = df_old.id);
+INSERT INTO datasetfieldvalue (datasetfield_id, value)
+SELECT df_new.id, dfv.value FROM datasetfield df_new
+JOIN datasetfieldtype dft_new ON df_new.datasetfieldtype_id = dft_new.id AND dft_new.name = 'cafeSourceDataAttribution'
+JOIN datasetfieldcompoundvalue dfcv ON df_new.parentdatasetfieldcompoundvalue_id = dfcv.id
+JOIN datasetfield df_comp ON dfcv.parentdatasetfield_id = df_comp.id
+JOIN datasetfieldtype dft_comp ON df_comp.datasetfieldtype_id = dft_comp.id AND dft_comp.name = 'cafeSourceData'
+JOIN datasetfield df_old ON df_old.datasetversion_id = df_comp.datasetversion_id
+JOIN datasetfieldtype dft_old ON df_old.datasetfieldtype_id = dft_old.id AND dft_old.name = 'cafeSourceDataAttribution'
+JOIN datasetfieldvalue dfv ON dfv.datasetfield_id = df_old.id;
+DELETE FROM datasetfieldvalue WHERE datasetfield_id IN (
+    SELECT df.id FROM datasetfield df JOIN datasetfieldtype dft ON df.datasetfieldtype_id = dft.id
+    WHERE dft.name = 'cafeSourceDataAttribution' AND df.parentdatasetfieldcompoundvalue_id IS NULL
+);
+DELETE FROM datasetfield WHERE datasetfieldtype_id = (
+    SELECT id FROM datasetfieldtype WHERE name = 'cafeSourceDataAttribution'
+) AND parentdatasetfieldcompoundvalue_id IS NULL;
+
+
+-- === cafeSourceDataDisclaimer ===
+INSERT INTO datasetfield (datasetfieldtype_id, parentdatasetfieldcompoundvalue_id)
+SELECT dft_new.id, dfcv.id FROM datasetfield df_comp
+JOIN datasetfieldtype dft_comp ON df_comp.datasetfieldtype_id = dft_comp.id AND dft_comp.name = 'cafeSourceData'
+JOIN datasetfieldcompoundvalue dfcv ON dfcv.parentdatasetfield_id = df_comp.id
+JOIN datasetfield df_old ON df_old.datasetversion_id = df_comp.datasetversion_id
+JOIN datasetfieldtype dft_old ON df_old.datasetfieldtype_id = dft_old.id AND dft_old.name = 'cafeSourceDataDisclaimer'
+JOIN datasetfieldtype dft_new ON dft_new.name = 'cafeSourceDataDisclaimer'
+WHERE EXISTS (SELECT 1 FROM datasetfieldvalue dfv WHERE dfv.datasetfield_id = df_old.id);
+INSERT INTO datasetfieldvalue (datasetfield_id, value)
+SELECT df_new.id, dfv.value FROM datasetfield df_new
+JOIN datasetfieldtype dft_new ON df_new.datasetfieldtype_id = dft_new.id AND dft_new.name = 'cafeSourceDataDisclaimer'
+JOIN datasetfieldcompoundvalue dfcv ON df_new.parentdatasetfieldcompoundvalue_id = dfcv.id
+JOIN datasetfield df_comp ON dfcv.parentdatasetfield_id = df_comp.id
+JOIN datasetfieldtype dft_comp ON df_comp.datasetfieldtype_id = dft_comp.id AND dft_comp.name = 'cafeSourceData'
+JOIN datasetfield df_old ON df_old.datasetversion_id = df_comp.datasetversion_id
+JOIN datasetfieldtype dft_old ON df_old.datasetfieldtype_id = dft_old.id AND dft_old.name = 'cafeSourceDataDisclaimer'
+JOIN datasetfieldvalue dfv ON dfv.datasetfield_id = df_old.id;
+DELETE FROM datasetfieldvalue WHERE datasetfield_id IN (
+    SELECT df.id FROM datasetfield df JOIN datasetfieldtype dft ON df.datasetfieldtype_id = dft.id
+    WHERE dft.name = 'cafeSourceDataDisclaimer' AND df.parentdatasetfieldcompoundvalue_id IS NULL
+);
+DELETE FROM datasetfield WHERE datasetfieldtype_id = (
+    SELECT id FROM datasetfieldtype WHERE name = 'cafeSourceDataDisclaimer'
+) AND parentdatasetfieldcompoundvalue_id IS NULL;

--- a/src/main/resources/db/migration/V6.6.0.1__cafe-metadata-restructure.sql
+++ b/src/main/resources/db/migration/V6.6.0.1__cafe-metadata-restructure.sql
@@ -1,4 +1,4 @@
--- Crear campo compuesto 'cafeSourceData' si no existe para cada dataset con datos
+-- Create compound field 'cafeSourceData' for datasets with data
 INSERT INTO datasetfield (datasetversion_id, datasetfieldtype_id)
 SELECT DISTINCT df.datasetversion_id,
        dft_comp.id
@@ -29,7 +29,7 @@ WHERE dft.name IN (
       AND df2.datasetfieldtype_id = dft_comp.id
 );
 
--- Crear compoundvalue si no existe
+-- Create compoundvalue if it doesn't exist
 INSERT INTO datasetfieldcompoundvalue (parentdatasetfield_id, displayorder)
 SELECT df.id, 0
 FROM datasetfield df
@@ -40,7 +40,7 @@ WHERE dft.name = 'cafeSourceData'
     WHERE dfcv.parentdatasetfield_id = df.id
 );
 
--- === cafeSourceDataTitle ===
+-- cafeSourceDataTitle
 INSERT INTO datasetfield (datasetfieldtype_id, parentdatasetfieldcompoundvalue_id)
 SELECT dft_new.id, dfcv.id FROM datasetfield df_comp
 JOIN datasetfieldtype dft_comp ON df_comp.datasetfieldtype_id = dft_comp.id AND dft_comp.name = 'cafeSourceData'
@@ -74,8 +74,8 @@ DELETE FROM datasetfield WHERE datasetfieldtype_id = (
     SELECT id FROM datasetfieldtype WHERE name = 'cafeSourceDataTitle'
 ) AND parentdatasetfieldcompoundvalue_id IS NULL;
 
--- === cafeSourceDataAuthor ===
--- Primero, crear el campo compuesto para cada dataset que tenga valores de autor
+-- cafeSourceDataAuthor
+-- Create compound field for datasets with author values
 INSERT INTO datasetfield (datasetfieldtype_id, parentdatasetfieldcompoundvalue_id)
 SELECT dft_new.id, dfcv.id FROM datasetfield df_comp
 JOIN datasetfieldtype dft_comp ON df_comp.datasetfieldtype_id = dft_comp.id AND dft_comp.name = 'cafeSourceData'
@@ -90,9 +90,8 @@ WHERE EXISTS (SELECT 1 FROM datasetfieldvalue dfv WHERE dfv.datasetfield_id = df
     WHERE df_new2.parentdatasetfieldcompoundvalue_id = dfcv.id
   );
 
--- Luego, insertar los valores de autor
--- Para cada dataset, crear un solo valor concatenado con todos los autores
--- Usando array_agg con ORDER BY para mantener el orden original y punto y coma como separador
+-- Insert concatenated author values with semicolon separator
+-- For each dataset, create a single value concatenated with all authors
 INSERT INTO datasetfieldvalue (datasetfield_id, value)
 SELECT 
     df_new.id, 
@@ -109,7 +108,7 @@ JOIN datasetfieldcompoundvalue dfcv ON df_new.parentdatasetfieldcompoundvalue_id
 JOIN datasetfield df_comp ON dfcv.parentdatasetfield_id = df_comp.id
 JOIN datasetfieldtype dft_comp ON df_comp.datasetfieldtype_id = dft_comp.id AND dft_comp.name = 'cafeSourceData';
 
--- Finalmente, eliminar los valores y campos originales
+-- Remove original author values and fields
 DELETE FROM datasetfieldvalue WHERE datasetfield_id IN (
     SELECT df.id FROM datasetfield df JOIN datasetfieldtype dft ON df.datasetfieldtype_id = dft.id
     WHERE dft.name = 'cafeSourceDataAuthor' AND df.parentdatasetfieldcompoundvalue_id IS NULL
@@ -120,7 +119,7 @@ DELETE FROM datasetfield WHERE datasetfieldtype_id = (
 ) AND parentdatasetfieldcompoundvalue_id IS NULL;
 
 
--- === cafeSourceDataInstitution ===
+-- cafeSourceDataInstitution
 INSERT INTO datasetfield (datasetfieldtype_id, parentdatasetfieldcompoundvalue_id)
 SELECT dft_new.id, dfcv.id FROM datasetfield df_comp
 JOIN datasetfieldtype dft_comp ON df_comp.datasetfieldtype_id = dft_comp.id AND dft_comp.name = 'cafeSourceData'
@@ -147,7 +146,7 @@ DELETE FROM datasetfield WHERE datasetfieldtype_id = (
 ) AND parentdatasetfieldcompoundvalue_id IS NULL;
 
 
--- === cafeSourceDataVersionNumber ===
+-- cafeSourceDataVersionNumber
 INSERT INTO datasetfield (datasetfieldtype_id, parentdatasetfieldcompoundvalue_id)
 SELECT dft_new.id, dfcv.id FROM datasetfield df_comp
 JOIN datasetfieldtype dft_comp ON df_comp.datasetfieldtype_id = dft_comp.id AND dft_comp.name = 'cafeSourceData'
@@ -174,7 +173,7 @@ DELETE FROM datasetfield WHERE datasetfieldtype_id = (
 ) AND parentdatasetfieldcompoundvalue_id IS NULL;
 
 
--- === cafeSourceDataDOIOrURL ===
+-- cafeSourceDataDOIOrURL
 INSERT INTO datasetfield (datasetfieldtype_id, parentdatasetfieldcompoundvalue_id)
 SELECT dft_new.id, dfcv.id FROM datasetfield df_comp
 JOIN datasetfieldtype dft_comp ON df_comp.datasetfieldtype_id = dft_comp.id AND dft_comp.name = 'cafeSourceData'
@@ -201,7 +200,7 @@ DELETE FROM datasetfield WHERE datasetfieldtype_id = (
 ) AND parentdatasetfieldcompoundvalue_id IS NULL;
 
 
--- === cafeSourceDataLastModifiedDate ===
+-- cafeSourceDataLastModifiedDate
 INSERT INTO datasetfield (datasetfieldtype_id, parentdatasetfieldcompoundvalue_id)
 SELECT dft_new.id, dfcv.id FROM datasetfield df_comp
 JOIN datasetfieldtype dft_comp ON df_comp.datasetfieldtype_id = dft_comp.id AND dft_comp.name = 'cafeSourceData'
@@ -228,7 +227,7 @@ DELETE FROM datasetfield WHERE datasetfieldtype_id = (
 ) AND parentdatasetfieldcompoundvalue_id IS NULL;
 
 
--- === cafeSourceDataDateObtained ===
+-- cafeSourceDataDateObtained
 INSERT INTO datasetfield (datasetfieldtype_id, parentdatasetfieldcompoundvalue_id)
 SELECT dft_new.id, dfcv.id FROM datasetfield df_comp
 JOIN datasetfieldtype dft_comp ON df_comp.datasetfieldtype_id = dft_comp.id AND dft_comp.name = 'cafeSourceData'
@@ -255,8 +254,8 @@ DELETE FROM datasetfield WHERE datasetfieldtype_id = (
 ) AND parentdatasetfieldcompoundvalue_id IS NULL;
 
 
--- === cafeSourceDataType ===
--- Crear campos compuestos para cada dataset que tenga valores de tipo
+-- cafeSourceDataType
+-- Create compound fields for datasets with type values
 INSERT INTO datasetfield (datasetfieldtype_id, parentdatasetfieldcompoundvalue_id)
 SELECT DISTINCT dft_new.id, dfcv.id 
 FROM datasetfield df_comp
@@ -275,7 +274,7 @@ AND NOT EXISTS (
     WHERE df_new2.parentdatasetfieldcompoundvalue_id = dfcv.id
 );
 
--- Copiar los valores de vocabulario controlado
+-- Copy controlled vocabulary values
 INSERT INTO datasetfield_controlledvocabularyvalue (datasetfield_id, controlledvocabularyvalues_id)
 SELECT df_new.id, dfcv2.controlledvocabularyvalues_id
 FROM datasetfield df_new
@@ -287,7 +286,7 @@ JOIN datasetfield df_old ON df_old.datasetversion_id = df_comp.datasetversion_id
 JOIN datasetfieldtype dft_old ON df_old.datasetfieldtype_id = dft_old.id AND dft_old.name = 'cafeSourceDataType'
 JOIN datasetfield_controlledvocabularyvalue dfcv2 ON dfcv2.datasetfield_id = df_old.id;
 
--- Eliminar las referencias en datasetfield_controlledvocabularyvalue
+-- Remove original references in datasetfield_controlledvocabularyvalue
 DELETE FROM datasetfield_controlledvocabularyvalue 
 WHERE datasetfield_id IN (
     SELECT df.id FROM datasetfield df 
@@ -295,14 +294,14 @@ WHERE datasetfield_id IN (
     WHERE dft.name = 'cafeSourceDataType' AND df.parentdatasetfieldcompoundvalue_id IS NULL
 );
 
--- Eliminar los campos antiguos
+-- Remove original fields
 DELETE FROM datasetfield 
 WHERE datasetfieldtype_id = (
     SELECT id FROM datasetfieldtype WHERE name = 'cafeSourceDataType'
 ) AND parentdatasetfieldcompoundvalue_id IS NULL;
 
 
--- === cafeSourceDataTypeOther ===
+-- cafeSourceDataTypeOther
 INSERT INTO datasetfield (datasetfieldtype_id, parentdatasetfieldcompoundvalue_id)
 SELECT dft_new.id, dfcv.id FROM datasetfield df_comp
 JOIN datasetfieldtype dft_comp ON df_comp.datasetfieldtype_id = dft_comp.id AND dft_comp.name = 'cafeSourceData'
@@ -329,8 +328,8 @@ DELETE FROM datasetfield WHERE datasetfieldtype_id = (
 ) AND parentdatasetfieldcompoundvalue_id IS NULL;
 
 
--- === cafeSourceDataSpatialResolution ===
--- Crear campos compuestos para cada dataset que tenga valores de spatial resolution
+-- cafeSourceDataSpatialResolution
+-- Create compound fields for datasets with spatial resolution values
 INSERT INTO datasetfield (datasetfieldtype_id, parentdatasetfieldcompoundvalue_id)
 SELECT DISTINCT dft_new.id, dfcv.id 
 FROM datasetfield df_comp
@@ -355,8 +354,8 @@ AND NOT EXISTS (
     WHERE df_new2.parentdatasetfieldcompoundvalue_id = dfcv.id
 );
 
--- === cafeSourceDataSpatialResolutionUnit ===
--- Crear campos compuestos para cada dataset que tenga valores de spatial resolution unit
+-- cafeSourceDataSpatialResolutionUnit
+-- Create compound fields for datasets with spatial resolution unit values
 INSERT INTO datasetfield (datasetfieldtype_id, parentdatasetfieldcompoundvalue_id)
 SELECT DISTINCT dft_new.id, dfcv.id 
 FROM datasetfield df_comp
@@ -381,8 +380,8 @@ AND NOT EXISTS (
     WHERE df_new2.parentdatasetfieldcompoundvalue_id = dfcv.id
 );
 
--- === cafeSourceDataSpatialResolutionUnitOther ===
--- Crear campos compuestos para cada dataset que tenga valores de spatial resolution unit other
+-- cafeSourceDataSpatialResolutionUnitOther
+-- Create compound fields for datasets with spatial resolution unit other values
 INSERT INTO datasetfield (datasetfieldtype_id, parentdatasetfieldcompoundvalue_id)
 SELECT DISTINCT dft_new.id, dfcv.id 
 FROM datasetfield df_comp
@@ -407,7 +406,7 @@ AND NOT EXISTS (
     WHERE df_new2.parentdatasetfieldcompoundvalue_id = dfcv.id
 );
 
--- Migrar valores de cafeSourceDataSpatialValue a cafeSourceDataSpatialResolution
+-- Migrate spatial value values to spatial resolution
 INSERT INTO datasetfieldvalue (datasetfield_id, value)
 SELECT df_new.id, dfv.value
 FROM datasetfield df_new
@@ -422,8 +421,8 @@ JOIN datasetfield df_sub ON df_sub.parentdatasetfieldcompoundvalue_id = dfcv_par
 JOIN datasetfieldtype dft_sub ON df_sub.datasetfieldtype_id = dft_sub.id AND dft_sub.name = 'cafeSourceDataSpatialValue'
 JOIN datasetfieldvalue dfv ON dfv.datasetfield_id = df_sub.id;
 
--- Migrar valores de cafeSourceDataSpatialResolutionUnit a cafeSourceDataSpatialResolutionUnit
--- Primero los valores de vocabulario controlado
+-- Migrate spatial resolution unit values to spatial resolution
+-- First, copy controlled vocabulary values
 INSERT INTO datasetfield_controlledvocabularyvalue (datasetfield_id, controlledvocabularyvalues_id)
 SELECT df_new.id, dfcv2.controlledvocabularyvalues_id
 FROM datasetfield df_new
@@ -438,7 +437,7 @@ JOIN datasetfield df_sub ON df_sub.parentdatasetfieldcompoundvalue_id = dfcv_par
 JOIN datasetfieldtype dft_sub ON df_sub.datasetfieldtype_id = dft_sub.id AND dft_sub.name = 'cafeSourceDataSpatialResolutionUnit'
 JOIN datasetfield_controlledvocabularyvalue dfcv2 ON dfcv2.datasetfield_id = df_sub.id;
 
--- Luego los valores normales
+-- Then, copy normal values
 INSERT INTO datasetfieldvalue (datasetfield_id, value)
 SELECT df_new.id, dfv.value
 FROM datasetfield df_new
@@ -457,7 +456,7 @@ WHERE NOT EXISTS (
     WHERE dfcv2.datasetfield_id = df_sub.id
 );
 
--- Migrar valores de cafeSourceDataSpatialResolutionUnitOther a cafeSourceDataSpatialResolutionUnitOther
+-- Migrate spatial resolution unit other values to spatial resolution unit other
 INSERT INTO datasetfieldvalue (datasetfield_id, value)
 SELECT df_new.id, dfv.value
 FROM datasetfield df_new
@@ -472,8 +471,7 @@ JOIN datasetfield df_sub ON df_sub.parentdatasetfieldcompoundvalue_id = dfcv_par
 JOIN datasetfieldtype dft_sub ON df_sub.datasetfieldtype_id = dft_sub.id AND dft_sub.name = 'cafeSourceDataSpatialResolutionUnitOther'
 JOIN datasetfieldvalue dfv ON dfv.datasetfield_id = df_sub.id;
 
--- Eliminar los valores y campos antiguos en el orden correcto
--- Primero eliminar las referencias en datasetfield_controlledvocabularyvalue para los subcampos
+-- Remove original references in datasetfield_controlledvocabularyvalue for subfields
 DELETE FROM datasetfield_controlledvocabularyvalue 
 WHERE datasetfield_id IN (
     SELECT df.id FROM datasetfield df 
@@ -487,7 +485,7 @@ WHERE datasetfield_id IN (
     )
 );
 
--- Luego eliminar los valores en datasetfieldvalue para los subcampos
+-- Remove original values in datasetfieldvalue for subfields
 DELETE FROM datasetfieldvalue 
 WHERE datasetfield_id IN (
     SELECT df.id FROM datasetfield df 
@@ -501,7 +499,7 @@ WHERE datasetfield_id IN (
     )
 );
 
--- Eliminar las referencias en datasetfieldcompoundvalue para los subcampos
+-- Remove references in datasetfieldcompoundvalue for subfields
 DELETE FROM datasetfieldcompoundvalue
 WHERE parentdatasetfield_id IN (
     SELECT df.id FROM datasetfield df 
@@ -515,7 +513,7 @@ WHERE parentdatasetfield_id IN (
     )
 );
 
--- Finalmente eliminar los campos subcampos
+-- Remove subfields
 DELETE FROM datasetfield 
 WHERE datasetfieldtype_id IN (
     SELECT id FROM datasetfieldtype 
@@ -528,7 +526,7 @@ AND parentdatasetfieldcompoundvalue_id IN (
     WHERE dft_parent.name = 'cafeSourceDataSpatialResolution'
 );
 
--- Eliminar las referencias en datasetfieldcompoundvalue para el campo padre
+-- Remove references in datasetfieldcompoundvalue for parent field
 DELETE FROM datasetfieldcompoundvalue
 WHERE parentdatasetfield_id IN (
     SELECT df.id FROM datasetfield df 
@@ -537,15 +535,15 @@ WHERE parentdatasetfield_id IN (
     AND df.parentdatasetfieldcompoundvalue_id IS NULL
 );
 
--- Finalmente eliminar el campo padre
+-- Remove parent field
 DELETE FROM datasetfield 
 WHERE datasetfieldtype_id = (
     SELECT id FROM datasetfieldtype WHERE name = 'cafeSourceDataSpatialResolution'
 ) AND parentdatasetfieldcompoundvalue_id IS NULL;
 
 
--- === cafeSourceDataTimestep ===
--- Crear campos compuestos para cada dataset que tenga valores de timestep
+-- cafeSourceDataTimestep
+-- Create compound fields for datasets with timestep values
 INSERT INTO datasetfield (datasetfieldtype_id, parentdatasetfieldcompoundvalue_id)
 SELECT DISTINCT dft_new.id, dfcv.id 
 FROM datasetfield df_comp
@@ -564,7 +562,7 @@ AND NOT EXISTS (
     WHERE df_new2.parentdatasetfieldcompoundvalue_id = dfcv.id
 );
 
--- Copiar los valores de vocabulario controlado
+-- Copy controlled vocabulary values
 INSERT INTO datasetfield_controlledvocabularyvalue (datasetfield_id, controlledvocabularyvalues_id)
 SELECT df_new.id, dfcv2.controlledvocabularyvalues_id
 FROM datasetfield df_new
@@ -576,7 +574,7 @@ JOIN datasetfield df_old ON df_old.datasetversion_id = df_comp.datasetversion_id
 JOIN datasetfieldtype dft_old ON df_old.datasetfieldtype_id = dft_old.id AND dft_old.name = 'cafeSourceDataTimestep'
 JOIN datasetfield_controlledvocabularyvalue dfcv2 ON dfcv2.datasetfield_id = df_old.id;
 
--- Eliminar las referencias en datasetfield_controlledvocabularyvalue
+-- Remove original references in datasetfield_controlledvocabularyvalue
 DELETE FROM datasetfield_controlledvocabularyvalue 
 WHERE datasetfield_id IN (
     SELECT df.id FROM datasetfield df 
@@ -584,14 +582,14 @@ WHERE datasetfield_id IN (
     WHERE dft.name = 'cafeSourceDataTimestep' AND df.parentdatasetfieldcompoundvalue_id IS NULL
 );
 
--- Eliminar los campos antiguos
+-- Remove original fields
 DELETE FROM datasetfield 
 WHERE datasetfieldtype_id = (
     SELECT id FROM datasetfieldtype WHERE name = 'cafeSourceDataTimestep'
 ) AND parentdatasetfieldcompoundvalue_id IS NULL;
 
 
--- === cafeSourceDataTimestepOther ===
+-- cafeSourceDataTimestepOther
 INSERT INTO datasetfield (datasetfieldtype_id, parentdatasetfieldcompoundvalue_id)
 SELECT dft_new.id, dfcv.id FROM datasetfield df_comp
 JOIN datasetfieldtype dft_comp ON df_comp.datasetfieldtype_id = dft_comp.id AND dft_comp.name = 'cafeSourceData'
@@ -618,7 +616,7 @@ DELETE FROM datasetfield WHERE datasetfieldtype_id = (
 ) AND parentdatasetfieldcompoundvalue_id IS NULL;
 
 
--- === cafeSourceDataAttribution ===
+-- cafeSourceDataAttribution
 INSERT INTO datasetfield (datasetfieldtype_id, parentdatasetfieldcompoundvalue_id)
 SELECT dft_new.id, dfcv.id FROM datasetfield df_comp
 JOIN datasetfieldtype dft_comp ON df_comp.datasetfieldtype_id = dft_comp.id AND dft_comp.name = 'cafeSourceData'
@@ -645,7 +643,7 @@ DELETE FROM datasetfield WHERE datasetfieldtype_id = (
 ) AND parentdatasetfieldcompoundvalue_id IS NULL;
 
 
--- === cafeSourceDataDisclaimer ===
+-- cafeSourceDataDisclaimer
 INSERT INTO datasetfield (datasetfieldtype_id, parentdatasetfieldcompoundvalue_id)
 SELECT dft_new.id, dfcv.id FROM datasetfield df_comp
 JOIN datasetfieldtype dft_comp ON df_comp.datasetfieldtype_id = dft_comp.id AND dft_comp.name = 'cafeSourceData'


### PR DESCRIPTION
**What this PR does / why we need it**:

This PR modifies the CAFE metadata block to support multiple data sources in datasets. The changes include:
- Restructuring the metadata block to allow multiple source datasets
- Adding a migration script to handle existing data
- Improving the display format of fields for better readability

Before this change, datasets could only specify one primary data source. Now, users can add multiple data sources with all their associated metadata (title, author, institution, etc.), making the metadata more accurate and complete.

**Which issue(s) this PR closes**:

- Closes #287 

Key changes:
1. Updated `customCAFEDataSources.tsv` to support multiple entries
2. Added migration script `V6.6.0.1__cafe-metadata-restructure.sql` to handle existing data
3. Improved field display format for better visualization

**Additional documentation**:

![image](https://github.com/user-attachments/assets/1404f9cd-9ecc-4f6b-86c0-a25ed8f94525)
![image](https://github.com/user-attachments/assets/adfca330-b9f3-414d-9e39-15f8a89672b7)
